### PR TITLE
Refactor XLink init code. Fix for init hang on RPi4 w/USB3

### DIFF
--- a/host/py_module/py_bindings.cpp
+++ b/host/py_module/py_bindings.cpp
@@ -90,7 +90,6 @@ bool init_device(
 
         g_xlink = std::unique_ptr<XLinkWrapper>(new XLinkWrapper(true));
 
-        std::cout << "depthai: before xlink init;\n";
         if (!g_xlink->initFromHostSide(
                 &g_xlink_global_handler,
                 &g_xlink_device_handler,
@@ -98,7 +97,7 @@ bool init_device(
                 true)
             )
         {
-            std::cout << "depthai: Error initalizing xlink;\n";
+            std::cout << "depthai: Error initializing xlink\n";
             break;
         }
 


### PR DESCRIPTION
- Use new API that no longer tries to match pre-boot and post-boot USB device addresses, resolving issue https://github.com/luxonis/depthai-python-extras/issues/40
- During init, wait for MyriadX USB device discovery for up to 10 seconds. Should resolve an issue that the device is not found after host app being closed and restarted immediately (delays from watchdog kicking in and/or USB enumeration).
- minor prints cleanup.

CC @itsderek23 @Luxonis-Brandon

(We should try merging PR's here by rebasing -- fast-forward merge, to reduce the occurrence of SHA changes for this repo used as a submodule in https://github.com/luxonis/depthai-python-extras/)