### PR TITLE
Fix (harmless) warning on Darwin systems

### DIFF
--- a/build_py_module.sh
+++ b/build_py_module.sh
@@ -3,11 +3,18 @@
 INITIAL_DIR=`pwd`
 SOURCE_DIR=$(dirname "$0")
 BUILD_DIR=build
+UNIX_NAME=`uname`
 
 # Default 'make' to a number of jobs equal to CPU threads, but lower it
 # if the memory available is too low, to avoid a lock up (e.g for RPi)
 NUM_JOBS=`nproc`
-MEM_AVAIL=`grep MemAvailable /proc/meminfo | awk '{print int($2/1024)}'`
+
+if [[ $UNIX_NAME = "Darwin" ]]; then
+    MEM_AVAIL=`sysctl hw.memsize | awk '{print int($2/1024/1024)}'`
+else
+    MEM_AVAIL=`grep MemAvailable /proc/meminfo | awk '{print int($2/1024)}'`
+fi
+
 echo "MemAvailable: $MEM_AVAIL MB"
 if [ -z $MEM_AVAIL ]; then echo "Unable to get MemAvailable"
 elif [[ $MEM_AVAIL -lt  900 ]]; then NUM_JOBS=1


### PR DESCRIPTION
Use sysctl on mac/darwin systems to remove a totally harmless warning that bugged me.