### PR TITLE
add configurable depth confidence threshold; remove limit for padding

### DIFF
--- a/host/core/pipeline/host_pipeline_config.cpp
+++ b/host/core/pipeline/host_pipeline_config.cpp
@@ -67,9 +67,9 @@ bool HostPipelineConfig::initWithJSON(const json &json_obj)
             {
                 depth.padding_factor = depth_obj.at("padding_factor").get<float>();
 
-                if (depth.padding_factor < 0.f || depth.padding_factor >= 0.5)
+                if (depth.padding_factor < 0.f || depth.padding_factor > 1.f)
                 {
-                    std::cout << "padding_factor should be in the range [0 .. 0.5)\n";
+                    std::cout << "padding_factor should be in the range [0 .. 1]\n";
                     break;
                 }
             }
@@ -77,6 +77,17 @@ bool HostPipelineConfig::initWithJSON(const json &json_obj)
             if (depth_obj.contains("depth_limit_m"))
             {
                 depth.depth_limit_m = depth_obj.at("depth_limit_m").get<float>();
+            }
+
+            if (depth_obj.contains("confidence_threshold"))
+            {
+                depth.confidence_threshold = depth_obj.at("confidence_threshold").get<float>();
+
+                if (depth.confidence_threshold < 0.f || depth.confidence_threshold > 1.f)
+                {
+                    std::cout << "confidence_threshold should be in the range [0 .. 1]\n";
+                    break;
+                }
             }
         }
 

--- a/host/core/pipeline/host_pipeline_config.hpp
+++ b/host/core/pipeline/host_pipeline_config.hpp
@@ -24,6 +24,7 @@ struct HostPipelineConfig
         std::string type;
         float       padding_factor = 0.3f;
         float       depth_limit_m = 10.0f;
+        float       confidence_threshold = 0.5f;
     } depth;
 
     struct AI

--- a/host/py_module/py_bindings.cpp
+++ b/host/py_module/py_bindings.cpp
@@ -441,6 +441,7 @@ std::shared_ptr<CNNHostPipeline> create_pipeline(
         };
         json_config_obj["depth"]["padding_factor"] = config.depth.padding_factor;
         json_config_obj["depth"]["depth_limit_mm"] = (int)(config.depth.depth_limit_m * 1000);
+        json_config_obj["depth"]["confidence_threshold"] = config.depth.confidence_threshold;
 
         json_config_obj["_load_inBlob"] = true;
         json_config_obj["_pipeline"] =


### PR DESCRIPTION
Add configurable depth confidence threshold: depth is calculated on bounding boxes with confidence higher or equal than the value set.
Remove limit for padding, from **[0,0.5)** to **[0,1]**