### PR TITLE
Don't limit packet sizes to > 16

### DIFF
--- a/host/core/pipeline/cnn_host_pipeline.cpp
+++ b/host/core/pipeline/cnn_host_pipeline.cpp
@@ -12,7 +12,7 @@ std::list<std::shared_ptr<NNetPacket>> CNNHostPipeline::getConsumedNNetPackets()
     // search for cnn result packet
     for (auto &packet : _consumed_packets)
     {
-        if ((packet->size() > 16) && (packet->stream_name == cnn_result_stream_name))
+        if ((packet->size() > 0) && (packet->stream_name == cnn_result_stream_name))
         {
             std::vector<std::shared_ptr<HostDataPacket>> tensors;
             tensors.push_back(packet);

--- a/host/core/pipeline/host_pipeline.cpp
+++ b/host/core/pipeline/host_pipeline.cpp
@@ -101,7 +101,7 @@ std::list<std::shared_ptr<HostDataPacket>> HostPipeline::getConsumedDataPackets(
 
     for (auto &packet : _consumed_packets)
     {
-        if ((packet->size() > 16) && (packet->stream_name != "metaout"))
+        if ((packet->size() > 0) && (packet->stream_name != "metaout"))
         {
             result.push_back(packet);
         }


### PR DESCRIPTION
Packets with sizes larger than 16 were ignored, which broke some networks with output of just a few bytes.