### PR TITLE
guard spsc queue push with mutex since it's not thread safe

### DIFF
--- a/host/core/pipeline/host_pipeline.cpp
+++ b/host/core/pipeline/host_pipeline.cpp
@@ -51,7 +51,6 @@ void HostPipeline::onNewData(
     if (!_data_queue_lf.push(host_data))
     {
         _data_queue_lf.pop();
-        guard.unlock();
         if (!_data_queue_lf.push(host_data))
         {
             std::cerr << "Data queue is full " << info.name << ":\n";

--- a/host/core/pipeline/host_pipeline.cpp
+++ b/host/core/pipeline/host_pipeline.cpp
@@ -47,9 +47,9 @@ void HostPipeline::onNewData(
             info.elem_size
             ));
 
+    std::unique_lock<std::mutex> guard(q_lock);
     if (!_data_queue_lf.push(host_data))
     {
-        std::unique_lock<std::mutex> guard(q_lock);
         _data_queue_lf.pop();
         guard.unlock();
         if (!_data_queue_lf.push(host_data))


### PR DESCRIPTION
SPSC (single producer-single consumer) queue [documentation](https://www.boost.org/doc/libs/1_53_0/doc/html/boost/lockfree/spsc_queue.html
) about queue `push` function:
`Requires: | only one thread is allowed to push data to the spsc_queue`
We had multiple threads calling `HostPipeline::onNewData` once USB packet arrived, queue push wasn't protected, so the data got released in between multiple threads pushing into queue and main python thread (consumer) consuming the queue.

This issue can be reproduced easily on commit e754c2b8bee5756d3db66d1b69b6834f9e14d484
w/ options : `./depthai.py -s previewout left right metaout -v /dev/null`
where each thread is spamming the queue -artificially- every 1 ms to reproduce the clash.
When the issue happens in the terminal it will be printed (most likely) : `Invalid packet stream name!deallocated`
but technically it's subject to undefined behavior due to corruption.

Protecting the queue in both consumer and producer defies the purpose of non locking queue, the purpose of this PR is not replacing the current queue implementation with a locking one, but to solve the current issue in the current context.